### PR TITLE
QACI-406 NPN compilable by JDK8u265

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>grizzly-npn</artifactId>
         <groupId>org.glassfish.grizzly</groupId>
-        <version>1.9.payara-p1</version>
+        <version>1.9.payara-p2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-npn-api</artifactId>

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>grizzly-npn</artifactId>
         <groupId>org.glassfish.grizzly</groupId>
-        <version>1.9.payara-p1</version>
+        <version>1.9.payara-p2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bootstrap/src/main/java/sun/security/ssl/ClientHandshaker.java
+++ b/bootstrap/src/main/java/sun/security/ssl/ClientHandshaker.java
@@ -614,15 +614,17 @@ final class ClientHandshaker extends Handshaker {
                             throw new SSLProtocolException("Server resumed" +
                                     " session with wrong subject identity");
                         } else {
-                            if (debug != null && Debug.isOn("session"))
+                            if (debug != null && Debug.isOn("session")) {
                                 System.out.println("Subject identity is same");
+                            }
                         }
                     } else {
-                        if (debug != null && Debug.isOn("session"))
+                        if (debug != null && Debug.isOn("session")) {
                             System.out.println("Kerberos credentials are not" +
                                     " present in the current Subject; check if " +
                                     " javax.security.auth.useSubjectAsCreds" +
                                     " system property has been set to false");
+                        }
                         throw new SSLProtocolException
                                 ("Server resumed session with no subject");
                     }
@@ -857,10 +859,10 @@ final class ClientHandshaker extends Handshaker {
 
             ArrayList<String> keytypesTmp = new ArrayList<>(4);
 
-            for (int i = 0; i < certRequest.types.length; i++) {
+            for (byte type : certRequest.types) {
                 String typeName;
 
-                switch (certRequest.types[i]) {
+                switch (type) {
                     case CertificateRequest.cct_rsa_sign:
                         typeName = "RSA";
                         break;
@@ -1186,7 +1188,7 @@ final class ClientHandshaker extends Handshaker {
                 if (protocolVersion.v >= ProtocolVersion.TLS12.v) {
                     preferableSignatureAlgorithm =
                             SignatureAndHashAlgorithm.getPreferableAlgorithm(
-                                    getPeerSupportedSignAlgs(), algorithmConstraints,
+                                    getPeerSupportedSignAlgs(),
                                     signingKey.getAlgorithm(), signingKey);
 
                     if (preferableSignatureAlgorithm == null) {
@@ -1325,13 +1327,11 @@ final class ClientHandshaker extends Handshaker {
     }
 
 
-    /*
+    /**
      * Returns a ClientHello message to kickstart renegotiations
      */
     @Override
     HandshakeMessage getKickstartMessage() throws SSLException {
-        // session ID of the ClientHello message
-        SessionId sessionId = SSLSessionImpl.nullSession.getSessionId();
 
         // a list of cipher suites sent by the client
         CipherSuiteList cipherSuites = getActiveCipherSuites();
@@ -1374,6 +1374,7 @@ final class ClientHandshaker extends Handshaker {
             }
         }
 
+        SessionId sessionId = new SessionId(false, null);
         if (session != null) {
             CipherSuite sessionSuite = session.getSuite();
             ProtocolVersion sessionVersion = session.getProtocolVersion();

--- a/bootstrap/src/main/java/sun/security/ssl/Handshaker.java
+++ b/bootstrap/src/main/java/sun/security/ssl/Handshaker.java
@@ -168,7 +168,7 @@ abstract class Handshaker {
 
     // Could probably use a java.util.concurrent.atomic.AtomicReference
     // here instead of using this lock.  Consider changing.
-    private Object thrownLock = new Object();
+    private final Object thrownLock = new Object();
 
     // Class and subclass dynamic debugging support
     static final Debug debug = Debug.getInstance("ssl");
@@ -455,7 +455,7 @@ abstract class Handshaker {
     void setPeerSupportedSignAlgs(
             Collection<SignatureAndHashAlgorithm> algorithms) {
         peerSupportedSignAlgs =
-                new ArrayList<SignatureAndHashAlgorithm>(algorithms);
+                new ArrayList<>(algorithms);
     }
 
     Collection<SignatureAndHashAlgorithm> getPeerSupportedSignAlgs() {
@@ -1454,12 +1454,13 @@ abstract class Handshaker {
      */
     class DelegatedTask<E> implements Runnable {
 
-        private PrivilegedExceptionAction<E> pea;
+        private final PrivilegedExceptionAction<E> pea;
 
         DelegatedTask(PrivilegedExceptionAction<E> pea) {
             this.pea = pea;
         }
 
+        @Override
         public void run() {
             synchronized (engine) {
                 try {
@@ -1476,7 +1477,7 @@ abstract class Handshaker {
     }
 
     private <T> void delegateTask(PrivilegedExceptionAction<T> pea) {
-        delegatedTask = new DelegatedTask<T>(pea);
+        delegatedTask = new DelegatedTask<>(pea);
         taskDelegated = false;
         thrown = null;
     }

--- a/bootstrap/src/main/java/sun/security/ssl/ServerHandshaker.java
+++ b/bootstrap/src/main/java/sun/security/ssl/ServerHandshaker.java
@@ -1339,7 +1339,7 @@ final class ServerHandshaker extends Handshaker {
                 if (protocolVersion.v >= ProtocolVersion.TLS12.v) {
                     preferableSignatureAlgorithm =
                             SignatureAndHashAlgorithm.getPreferableAlgorithm(
-                                    supportedSignAlgs, algorithmConstraints, "RSA", privateKey);
+                                    supportedSignAlgs, "RSA", privateKey);
                     if (preferableSignatureAlgorithm == null) {
                         if ((debug != null) && Debug.isOn("handshake")) {
                             System.out.println(
@@ -1362,7 +1362,7 @@ final class ServerHandshaker extends Handshaker {
                 if (protocolVersion.v >= ProtocolVersion.TLS12.v) {
                     preferableSignatureAlgorithm =
                             SignatureAndHashAlgorithm.getPreferableAlgorithm(
-                                    supportedSignAlgs, algorithmConstraints, "RSA", privateKey);
+                                    supportedSignAlgs, "RSA", privateKey);
                     if (preferableSignatureAlgorithm == null) {
                         if ((debug != null) && Debug.isOn("handshake")) {
                             System.out.println(
@@ -1382,7 +1382,7 @@ final class ServerHandshaker extends Handshaker {
                 if (protocolVersion.v >= ProtocolVersion.TLS12.v) {
                     preferableSignatureAlgorithm =
                             SignatureAndHashAlgorithm.getPreferableAlgorithm(
-                                    supportedSignAlgs, algorithmConstraints, "DSA");
+                                    supportedSignAlgs, "DSA");
                     if (preferableSignatureAlgorithm == null) {
                         if ((debug != null) && Debug.isOn("handshake")) {
                             System.out.println(
@@ -1405,7 +1405,7 @@ final class ServerHandshaker extends Handshaker {
                 if (protocolVersion.v >= ProtocolVersion.TLS12.v) {
                     preferableSignatureAlgorithm =
                             SignatureAndHashAlgorithm.getPreferableAlgorithm(
-                                    supportedSignAlgs, algorithmConstraints, "ECDSA");
+                                    supportedSignAlgs, "ECDSA");
                     if (preferableSignatureAlgorithm == null) {
                         if ((debug != null) && Debug.isOn("handshake")) {
                             System.out.println(

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>grizzly-npn</artifactId>
         <groupId>org.glassfish.grizzly</groupId>
-        <version>1.9.payara-p1</version>
+        <version>1.9.payara-p2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <groupId>org.glassfish.grizzly</groupId>
     <artifactId>grizzly-npn</artifactId>
     <packaging>pom</packaging>
-    <version>1.9.payara-p1</version>
+    <version>1.9.payara-p2-SNAPSHOT</version>
 
     <url>http://grizzly.java.net</url>
     <issueManagement>


### PR DESCRIPTION
- Compilable with JDK8u265
- Not required for Payara 5.2020.5 as it is configured to use JDK default implementation OR older NPN versions, but useful to see differences in JSSE API.
