### PR TITLE
FISH-6392:improving memory for alpn negotiator maps

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>grizzly-npn</artifactId>
         <groupId>org.glassfish.grizzly</groupId>
-        <version>1.9.payara-p2-SNAPSHOT</version>
+        <version>1.9.payara-p2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-npn-api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>grizzly-npn</artifactId>
         <groupId>org.glassfish.grizzly</groupId>
-        <version>1.9.payara-p2</version>
+        <version>1.9.payara-p3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-npn-api</artifactId>

--- a/api/src/main/java/org/glassfish/grizzly/npn/NegotiationSupport.java
+++ b/api/src/main/java/org/glassfish/grizzly/npn/NegotiationSupport.java
@@ -26,13 +26,13 @@ import java.util.concurrent.ConcurrentHashMap;
 public class NegotiationSupport {
 
     private static final ConcurrentHashMap<String, ServerSideNegotiator> serverSideNegotiators =
-            new ConcurrentHashMap<>(4);
+            new ConcurrentHashMap<>();
     private static final ConcurrentHashMap<String, ClientSideNegotiator> clientSideNegotiators =
-                new ConcurrentHashMap<>(4);
+                new ConcurrentHashMap<>();
     private static final ConcurrentHashMap<String, AlpnServerNegotiator> alpnServerNegotiators =
-                new ConcurrentHashMap<>(4);
+                new ConcurrentHashMap<>();
         private static final ConcurrentHashMap<String, AlpnClientNegotiator> alpnClientNegotiators =
-                    new ConcurrentHashMap<>(4);
+                    new ConcurrentHashMap<>();
 
     /**
      * Add a {@link ServerSideNegotiator} that will be invoked when handshake

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>grizzly-npn</artifactId>
         <groupId>org.glassfish.grizzly</groupId>
-        <version>1.9.payara-p2</version>
+        <version>1.9.payara-p3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>grizzly-npn</artifactId>
         <groupId>org.glassfish.grizzly</groupId>
-        <version>1.9.payara-p2-SNAPSHOT</version>
+        <version>1.9.payara-p2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>grizzly-npn</artifactId>
         <groupId>org.glassfish.grizzly</groupId>
-        <version>1.9.payara-p2-SNAPSHOT</version>
+        <version>1.9.payara-p2</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>grizzly-npn</artifactId>
         <groupId>org.glassfish.grizzly</groupId>
-        <version>1.9.payara-p2</version>
+        <version>1.9.payara-p3-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <groupId>org.glassfish.grizzly</groupId>
     <artifactId>grizzly-npn</artifactId>
     <packaging>pom</packaging>
-    <version>1.9.payara-p2-SNAPSHOT</version>
+    <version>1.9.payara-p2</version>
 
     <url>http://grizzly.java.net</url>
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <groupId>org.glassfish.grizzly</groupId>
     <artifactId>grizzly-npn</artifactId>
     <packaging>pom</packaging>
-    <version>1.9.payara-p2</version>
+    <version>1.9.payara-p3-SNAPSHOT</version>
 
     <url>http://grizzly.java.net</url>
     <issueManagement>


### PR DESCRIPTION
Improving ConcurrentHashMaps using String key instead of SSLEngine instance 

Tests
Tested on local environment by calling a rest service using https on Payara 5 Server
Build Environment:
Windows 11, Oracle JDK 8 u 251, Maven 3.8.3