### PR TITLE
Fish-6392: improve memory for alpn negotiator maps payara6

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>grizzly-npn</artifactId>
         <groupId>org.glassfish.grizzly</groupId>
-        <version>2.0.0.payara-p1</version>
+        <version>2.0.0.payara-p2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-npn-api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>grizzly-npn</artifactId>
         <groupId>org.glassfish.grizzly</groupId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-npn-api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>grizzly-npn</artifactId>
         <groupId>org.glassfish.grizzly</groupId>
-        <version>2.0.1</version>
+        <version>2.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-npn-api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>grizzly-npn</artifactId>
         <groupId>org.glassfish.grizzly</groupId>
-        <version>2.0.2-SNAPSHOT</version>
+        <version>2.0.0.payara-p1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-npn-api</artifactId>

--- a/api/src/main/java/org/glassfish/grizzly/npn/NegotiationSupport.java
+++ b/api/src/main/java/org/glassfish/grizzly/npn/NegotiationSupport.java
@@ -26,13 +26,13 @@ import java.util.concurrent.ConcurrentHashMap;
 public class NegotiationSupport {
 
     private static final ConcurrentHashMap<String, ServerSideNegotiator> serverSideNegotiators =
-            new ConcurrentHashMap<>(4);
+            new ConcurrentHashMap<>();
     private static final ConcurrentHashMap<String, ClientSideNegotiator> clientSideNegotiators =
-                new ConcurrentHashMap<>(4);
+                new ConcurrentHashMap<>();
     private static final ConcurrentHashMap<String, AlpnServerNegotiator> alpnServerNegotiators =
-                new ConcurrentHashMap<>(4);
+                new ConcurrentHashMap<>();
         private static final ConcurrentHashMap<String, AlpnClientNegotiator> alpnClientNegotiators =
-                    new ConcurrentHashMap<>(4);
+                    new ConcurrentHashMap<>();
 
     /**
      * Add a {@link ServerSideNegotiator} that will be invoked when handshake

--- a/api/src/main/java/org/glassfish/grizzly/npn/NegotiationSupport.java
+++ b/api/src/main/java/org/glassfish/grizzly/npn/NegotiationSupport.java
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-// Portions Copyright [2022] [Payara Foundation and/or its affiliates]
+
 package org.glassfish.grizzly.npn;
 
 import javax.net.ssl.SSLEngine;
@@ -25,14 +25,14 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class NegotiationSupport {
 
-    private static final ConcurrentHashMap<String, ServerSideNegotiator> serverSideNegotiators =
-            new ConcurrentHashMap<>(4);
-    private static final ConcurrentHashMap<String, ClientSideNegotiator> clientSideNegotiators =
-                new ConcurrentHashMap<>(4);
-    private static final ConcurrentHashMap<String, AlpnServerNegotiator> alpnServerNegotiators =
-                new ConcurrentHashMap<>(4);
-        private static final ConcurrentHashMap<String, AlpnClientNegotiator> alpnClientNegotiators =
-                    new ConcurrentHashMap<>(4);
+    private static final ConcurrentHashMap<SSLEngine, ServerSideNegotiator> serverSideNegotiators =
+            new ConcurrentHashMap<SSLEngine, ServerSideNegotiator>(4);
+    private static final ConcurrentHashMap<SSLEngine, ClientSideNegotiator> clientSideNegotiators =
+                new ConcurrentHashMap<SSLEngine, ClientSideNegotiator>(4);
+    private static final ConcurrentHashMap<SSLEngine, AlpnServerNegotiator> alpnServerNegotiators =
+                new ConcurrentHashMap<SSLEngine, AlpnServerNegotiator>(4);
+        private static final ConcurrentHashMap<SSLEngine, AlpnClientNegotiator> alpnClientNegotiators =
+                    new ConcurrentHashMap<SSLEngine, AlpnClientNegotiator>(4);
 
     /**
      * Add a {@link ServerSideNegotiator} that will be invoked when handshake
@@ -40,7 +40,7 @@ public class NegotiationSupport {
      */
     public static void addNegotiator(final SSLEngine engine,
                                      final ServerSideNegotiator serverSideNegotiator) {
-        serverSideNegotiators.putIfAbsent(generateKey(engine), serverSideNegotiator);
+        serverSideNegotiators.putIfAbsent(engine, serverSideNegotiator);
     }
 
     /**
@@ -49,7 +49,7 @@ public class NegotiationSupport {
      */
     public static void addNegotiator(final SSLEngine engine,
                                      final ClientSideNegotiator clientSideNegotiator) {
-        clientSideNegotiators.putIfAbsent(generateKey(engine), clientSideNegotiator);
+        clientSideNegotiators.putIfAbsent(engine, clientSideNegotiator);
     }
 
     /**
@@ -58,7 +58,7 @@ public class NegotiationSupport {
      */
     public static void addNegotiator(final SSLEngine engine,
                                      final AlpnServerNegotiator serverSideNegotiator) {
-        alpnServerNegotiators.putIfAbsent(generateKey(engine), serverSideNegotiator);
+        alpnServerNegotiators.putIfAbsent(engine, serverSideNegotiator);
     }
 
     /**
@@ -67,7 +67,7 @@ public class NegotiationSupport {
      */
     public static void addNegotiator(final SSLEngine engine,
                                      final AlpnClientNegotiator clientSideNegotiator) {
-        alpnClientNegotiators.putIfAbsent(generateKey(engine), clientSideNegotiator);
+        alpnClientNegotiators.putIfAbsent(engine, clientSideNegotiator);
     }
 
     /**
@@ -75,7 +75,7 @@ public class NegotiationSupport {
      * {@link SSLEngine}.
      */
     public static ClientSideNegotiator removeClientNegotiator(final SSLEngine engine) {
-        return clientSideNegotiators.remove(generateKey(engine));
+        return clientSideNegotiators.remove(engine);
     }
 
     /**
@@ -83,7 +83,7 @@ public class NegotiationSupport {
      * {@link SSLEngine}.
      */
     public static AlpnClientNegotiator removeAlpnClientNegotiator(final SSLEngine engine) {
-        return alpnClientNegotiators.remove(generateKey(engine));
+        return alpnClientNegotiators.remove(engine);
     }
 
     /**
@@ -91,7 +91,7 @@ public class NegotiationSupport {
      * {@link SSLEngine}.
      */
     public static ServerSideNegotiator removeServerNegotiator(final SSLEngine engine) {
-        return serverSideNegotiators.remove(generateKey(engine));
+        return serverSideNegotiators.remove(engine);
     }
 
     /**
@@ -99,7 +99,7 @@ public class NegotiationSupport {
      * {@link SSLEngine}.
      */
     public static AlpnServerNegotiator removeAlpnServerNegotiator(final SSLEngine engine) {
-        return alpnServerNegotiators.remove(generateKey(engine));
+        return alpnServerNegotiators.remove(engine);
     }
 
     /**
@@ -107,7 +107,7 @@ public class NegotiationSupport {
      * {@link SSLEngine}.
      */
     public static ServerSideNegotiator getServerSideNegotiator(final SSLEngine engine) {
-        return serverSideNegotiators.get(generateKey(engine));
+        return serverSideNegotiators.get(engine);
     }
 
     /**
@@ -115,7 +115,7 @@ public class NegotiationSupport {
      * {@link SSLEngine}.
      */
     public static ClientSideNegotiator getClientSideNegotiator(final SSLEngine engine) {
-        return clientSideNegotiators.get(generateKey(engine));
+        return clientSideNegotiators.get(engine);
     }
 
     /**
@@ -123,7 +123,7 @@ public class NegotiationSupport {
      * {@link SSLEngine}.
      */
     public static AlpnServerNegotiator getAlpnServerNegotiator(final SSLEngine engine) {
-        return alpnServerNegotiators.get(generateKey(engine));
+        return alpnServerNegotiators.get(engine);
     }
 
     /**
@@ -131,19 +131,7 @@ public class NegotiationSupport {
      * {@link SSLEngine}.
      */
     public static AlpnClientNegotiator getAlpnClientNegotiator(final SSLEngine engine) {
-        return alpnClientNegotiators.get(generateKey(engine));
-    }
-
-    /**
-     * This generates a key for the SSLEngine
-     * @param engine instance of type SSLEngine used for the ALPN implementation
-     * @return String with the key formed with Class Name and hashCode
-     */
-    private static String generateKey(SSLEngine engine){
-        if(engine != null) {
-            return engine.getClass().getName() + "@" + Integer.toHexString(engine.hashCode());
-        }
-        return null;
+        return alpnClientNegotiators.get(engine);
     }
 
 }

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>grizzly-npn</artifactId>
         <groupId>org.glassfish.grizzly</groupId>
-        <version>2.0.2-SNAPSHOT</version>
+        <version>2.0.0.payara-p1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>grizzly-npn</artifactId>
         <groupId>org.glassfish.grizzly</groupId>
-        <version>2.0.0.payara-p1</version>
+        <version>2.0.0.payara-p2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>grizzly-npn</artifactId>
         <groupId>org.glassfish.grizzly</groupId>
-        <version>2.0.1</version>
+        <version>2.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>grizzly-npn</artifactId>
         <groupId>org.glassfish.grizzly</groupId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bootstrap/src/main/java/sun/security/ssl/ClientHandshaker.java
+++ b/bootstrap/src/main/java/sun/security/ssl/ClientHandshaker.java
@@ -607,15 +607,17 @@ final class ClientHandshaker extends Handshaker {
                             throw new SSLProtocolException("Server resumed" +
                                     " session with wrong subject identity");
                         } else {
-                            if (debug != null && Debug.isOn("session"))
+                            if (debug != null && Debug.isOn("session")) {
                                 System.out.println("Subject identity is same");
+                            }
                         }
                     } else {
-                        if (debug != null && Debug.isOn("session"))
+                        if (debug != null && Debug.isOn("session")) {
                             System.out.println("Kerberos credentials are not" +
                                     " present in the current Subject; check if " +
                                     " javax.security.auth.useSubjectAsCreds" +
                                     " system property has been set to false");
+                        }
                         throw new SSLProtocolException
                                 ("Server resumed session with no subject");
                     }
@@ -850,10 +852,10 @@ final class ClientHandshaker extends Handshaker {
 
             ArrayList<String> keytypesTmp = new ArrayList<>(4);
 
-            for (int i = 0; i < certRequest.types.length; i++) {
+            for (byte type : certRequest.types) {
                 String typeName;
 
-                switch (certRequest.types[i]) {
+                switch (type) {
                     case CertificateRequest.cct_rsa_sign:
                         typeName = "RSA";
                         break;
@@ -1320,13 +1322,11 @@ final class ClientHandshaker extends Handshaker {
     }
 
 
-    /*
+    /**
      * Returns a ClientHello message to kickstart renegotiations
      */
     @Override
     HandshakeMessage getKickstartMessage() throws SSLException {
-        // session ID of the ClientHello message
-        SessionId sessionId = SSLSessionImpl.nullSession.getSessionId();
 
         // a list of cipher suites sent by the client
         CipherSuiteList cipherSuites = getActiveCipherSuites();
@@ -1369,6 +1369,7 @@ final class ClientHandshaker extends Handshaker {
             }
         }
 
+        SessionId sessionId = new SessionId(false, null);
         if (session != null) {
             CipherSuite sessionSuite = session.getSuite();
             ProtocolVersion sessionVersion = session.getProtocolVersion();

--- a/bootstrap/src/main/java/sun/security/ssl/ClientHandshaker.java
+++ b/bootstrap/src/main/java/sun/security/ssl/ClientHandshaker.java
@@ -614,15 +614,17 @@ final class ClientHandshaker extends Handshaker {
                             throw new SSLProtocolException("Server resumed" +
                                     " session with wrong subject identity");
                         } else {
-                            if (debug != null && Debug.isOn("session"))
+                            if (debug != null && Debug.isOn("session")) {
                                 System.out.println("Subject identity is same");
+                            }
                         }
                     } else {
-                        if (debug != null && Debug.isOn("session"))
+                        if (debug != null && Debug.isOn("session")) {
                             System.out.println("Kerberos credentials are not" +
                                     " present in the current Subject; check if " +
                                     " javax.security.auth.useSubjectAsCreds" +
                                     " system property has been set to false");
+                        }
                         throw new SSLProtocolException
                                 ("Server resumed session with no subject");
                     }
@@ -857,10 +859,10 @@ final class ClientHandshaker extends Handshaker {
 
             ArrayList<String> keytypesTmp = new ArrayList<>(4);
 
-            for (int i = 0; i < certRequest.types.length; i++) {
+            for (byte type : certRequest.types) {
                 String typeName;
 
-                switch (certRequest.types[i]) {
+                switch (type) {
                     case CertificateRequest.cct_rsa_sign:
                         typeName = "RSA";
                         break;
@@ -1325,13 +1327,11 @@ final class ClientHandshaker extends Handshaker {
     }
 
 
-    /*
+    /**
      * Returns a ClientHello message to kickstart renegotiations
      */
     @Override
     HandshakeMessage getKickstartMessage() throws SSLException {
-        // session ID of the ClientHello message
-        SessionId sessionId = SSLSessionImpl.nullSession.getSessionId();
 
         // a list of cipher suites sent by the client
         CipherSuiteList cipherSuites = getActiveCipherSuites();
@@ -1374,6 +1374,7 @@ final class ClientHandshaker extends Handshaker {
             }
         }
 
+        SessionId sessionId = new SessionId(false, null);
         if (session != null) {
             CipherSuite sessionSuite = session.getSuite();
             ProtocolVersion sessionVersion = session.getProtocolVersion();

--- a/bootstrap/src/main/java/sun/security/ssl/ClientHandshaker.java
+++ b/bootstrap/src/main/java/sun/security/ssl/ClientHandshaker.java
@@ -607,17 +607,15 @@ final class ClientHandshaker extends Handshaker {
                             throw new SSLProtocolException("Server resumed" +
                                     " session with wrong subject identity");
                         } else {
-                            if (debug != null && Debug.isOn("session")) {
+                            if (debug != null && Debug.isOn("session"))
                                 System.out.println("Subject identity is same");
-                            }
                         }
                     } else {
-                        if (debug != null && Debug.isOn("session")) {
+                        if (debug != null && Debug.isOn("session"))
                             System.out.println("Kerberos credentials are not" +
                                     " present in the current Subject; check if " +
                                     " javax.security.auth.useSubjectAsCreds" +
                                     " system property has been set to false");
-                        }
                         throw new SSLProtocolException
                                 ("Server resumed session with no subject");
                     }
@@ -852,10 +850,10 @@ final class ClientHandshaker extends Handshaker {
 
             ArrayList<String> keytypesTmp = new ArrayList<>(4);
 
-            for (byte type : certRequest.types) {
+            for (int i = 0; i < certRequest.types.length; i++) {
                 String typeName;
 
-                switch (type) {
+                switch (certRequest.types[i]) {
                     case CertificateRequest.cct_rsa_sign:
                         typeName = "RSA";
                         break;
@@ -1322,11 +1320,13 @@ final class ClientHandshaker extends Handshaker {
     }
 
 
-    /**
+    /*
      * Returns a ClientHello message to kickstart renegotiations
      */
     @Override
     HandshakeMessage getKickstartMessage() throws SSLException {
+        // session ID of the ClientHello message
+        SessionId sessionId = SSLSessionImpl.nullSession.getSessionId();
 
         // a list of cipher suites sent by the client
         CipherSuiteList cipherSuites = getActiveCipherSuites();
@@ -1369,7 +1369,6 @@ final class ClientHandshaker extends Handshaker {
             }
         }
 
-        SessionId sessionId = new SessionId(false, null);
         if (session != null) {
             CipherSuite sessionSuite = session.getSuite();
             ProtocolVersion sessionVersion = session.getProtocolVersion();

--- a/bootstrap/src/main/java/sun/security/ssl/ClientHandshaker.java
+++ b/bootstrap/src/main/java/sun/security/ssl/ClientHandshaker.java
@@ -185,19 +185,23 @@ final class ClientHandshaker extends Handshaker {
      */
     @Override
     void processMessage(byte type, int messageLen) throws IOException {
-        if (state >= type
-                && (type != HandshakeMessage.ht_hello_request)) {
-            throw new SSLProtocolException(
-                    "Handshake message sequence violation, " + type);
-        }
+        // check the handshake state
+        List<Byte> ignoredOptStates = handshakeState.check(type);
 
         switch (type) {
             case HandshakeMessage.ht_hello_request:
-                this.serverHelloRequest(new HelloRequest(input));
+                HelloRequest helloRequest = new HelloRequest(input);
+                handshakeState.update(helloRequest, resumingSession);
+                this.serverHelloRequest(helloRequest);
                 break;
 
             case HandshakeMessage.ht_server_hello:
-                this.serverHello(new ServerHello(input, messageLen));
+                ServerHello serverHello = new ServerHello(input, messageLen);
+                this.serverHello(serverHello);
+
+                // This handshake state update needs the resumingSession value
+                // set by serverHello().
+                handshakeState.update(serverHello, resumingSession);
                 break;
 
             case HandshakeMessage.ht_certificate:
@@ -207,7 +211,9 @@ final class ClientHandshaker extends Handshaker {
                             "unexpected server cert chain");
                     // NOTREACHED
                 }
-                this.serverCertificate(new CertificateMsg(input));
+                CertificateMsg certificateMsg = new CertificateMsg(input);
+                handshakeState.update(certificateMsg, resumingSession);
+                this.serverCertificate(certificateMsg);
                 serverKey =
                         session.getPeerCertificates()[0].getPublicKey();
                 break;
@@ -243,15 +249,20 @@ final class ClientHandshaker extends Handshaker {
                         }
 
                         try {
-                            this.serverKeyExchange(new RSA_ServerKeyExchange(input));
+                            RSA_ServerKeyExchange rsaSrvKeyExchange =
+                                    new RSA_ServerKeyExchange(input);
+                            handshakeState.update(rsaSrvKeyExchange, resumingSession);
+                            this.serverKeyExchange(rsaSrvKeyExchange);
                         } catch (GeneralSecurityException e) {
                             throwSSLException("Server key", e);
                         }
                         break;
                     case K_DH_ANON:
                         try {
-                            this.serverKeyExchange(new DH_ServerKeyExchange(
-                                    input, protocolVersion));
+                            DH_ServerKeyExchange dhSrvKeyExchange =
+                                    new DH_ServerKeyExchange(input, protocolVersion);
+                            handshakeState.update(dhSrvKeyExchange, resumingSession);
+                            this.serverKeyExchange(dhSrvKeyExchange);
                         } catch (GeneralSecurityException e) {
                             throwSSLException("Server key", e);
                         }
@@ -259,11 +270,14 @@ final class ClientHandshaker extends Handshaker {
                     case K_DHE_DSS:
                     case K_DHE_RSA:
                         try {
-                            this.serverKeyExchange(new DH_ServerKeyExchange(
-                                    input, serverKey,
-                                    clnt_random.random_bytes, svr_random.random_bytes,
-                                    messageLen,
-                                    getLocalSupportedSignAlgs(), protocolVersion));
+                            DH_ServerKeyExchange dhSrvKeyExchange =
+                                    new DH_ServerKeyExchange(
+                                            input, serverKey,
+                                            clnt_random.random_bytes, svr_random.random_bytes,
+                                            messageLen,
+                                            getLocalSupportedSignAlgs(), protocolVersion);
+                            handshakeState.update(dhSrvKeyExchange, resumingSession);
+                            this.serverKeyExchange(dhSrvKeyExchange);
                         } catch (GeneralSecurityException e) {
                             throwSSLException("Server key", e);
                         }
@@ -272,10 +286,13 @@ final class ClientHandshaker extends Handshaker {
                     case K_ECDHE_RSA:
                     case K_ECDH_ANON:
                         try {
-                            this.serverKeyExchange(new ECDH_ServerKeyExchange
-                                    (input, serverKey, clnt_random.random_bytes,
-                                            svr_random.random_bytes,
-                                            getLocalSupportedSignAlgs(), protocolVersion));
+                            ECDH_ServerKeyExchange ecdhSrvKeyExchange =
+                                    new ECDH_ServerKeyExchange
+                                            (input, serverKey, clnt_random.random_bytes,
+                                                    svr_random.random_bytes,
+                                                    getLocalSupportedSignAlgs(), protocolVersion);
+                            handshakeState.update(ecdhSrvKeyExchange, resumingSession);
+                            this.serverKeyExchange(ecdhSrvKeyExchange);
                         } catch (GeneralSecurityException e) {
                             throwSSLException("Server key", e);
                         }
@@ -314,6 +331,7 @@ final class ClientHandshaker extends Handshaker {
                 if (debug != null && Debug.isOn("handshake")) {
                     certRequest.print(System.out);
                 }
+                handshakeState.update(certRequest, resumingSession);
 
                 if (protocolVersion.v >= ProtocolVersion.TLS12.v) {
                     Collection<SignatureAndHashAlgorithm> peerSignAlgs =
@@ -339,32 +357,21 @@ final class ClientHandshaker extends Handshaker {
                 break;
 
             case HandshakeMessage.ht_server_hello_done:
-                this.serverHelloDone(new ServerHelloDone(input));
+                ServerHelloDone serverHelloDone = new ServerHelloDone(input);
+                handshakeState.update(serverHelloDone, resumingSession);
+                this.serverHelloDone(serverHelloDone);
                 break;
 
             case HandshakeMessage.ht_finished:
-                // A ChangeCipherSpec record must have been received prior to
-                // reception of the Finished message (RFC 5246, 7.4.9).
-                if (!receivedChangeCipherSpec()) {
-                    fatalSE(Alerts.alert_handshake_failure,
-                            "Received Finished message before ChangeCipherSpec");
-                }
-
-                this.serverFinished(
-                        new Finished(protocolVersion, input, cipherSuite));
+                Finished serverFinished =
+                        new Finished(protocolVersion, input, cipherSuite);
+                handshakeState.update(serverFinished, resumingSession);
+                this.serverFinished(serverFinished);
                 break;
 
             default:
                 throw new SSLProtocolException(
                         "Illegal client handshake msg, " + type);
-        }
-
-        //
-        // Move state machine forward if the message handling
-        // code didn't already do so
-        //
-        if (state < type) {
-            state = type;
         }
     }
 
@@ -383,7 +390,7 @@ final class ClientHandshaker extends Handshaker {
         // Could be (e.g. at connection setup) that we already
         // sent the "client hello" but the server's not seen it.
         //
-        if (state < HandshakeMessage.ht_client_hello) {
+        if (!clientHelloDelivered) {
             if (!secureRenegotiation && !allowUnsafeRenegotiation) {
                 // renegotiation is not allowed.
                 if (activeProtocolVersion.v >= ProtocolVersion.TLS10.v) {
@@ -623,7 +630,6 @@ final class ClientHandshaker extends Handshaker {
 
                 // looks fine; resume it, and update the state machine.
                 resumingSession = true;
-                state = HandshakeMessage.ht_finished - 1;
                 calculateConnectionKeys(session.getMasterSecret());
                 if (debug != null && Debug.isOn("session")) {
                     System.out.println("%% Server resumed " + session);
@@ -750,7 +756,8 @@ final class ClientHandshaker extends Handshaker {
         session = new SSLSessionImpl(protocolVersion, cipherSuite,
                 getLocalSupportedSignAlgs(),
                 mesg.sessionId, getHostSE(), getPortSE(),
-                (extendedMasterSecretExt != null));
+                (extendedMasterSecretExt != null),
+                getEndpointIdentificationAlgorithmSE());
         session.setRequestedServerNames(requestedServerNames);
         setHandshakeSessionSE(session);
         if (debug != null && Debug.isOn("handshake")) {
@@ -942,6 +949,7 @@ final class ClientHandshaker extends Handshaker {
                     m1.print(System.out);
                 }
                 m1.write(output);
+                handshakeState.update(m1, resumingSession);
             }
         }
 
@@ -1106,6 +1114,7 @@ final class ClientHandshaker extends Handshaker {
         }
         m2.write(output);
 
+        handshakeState.update(m2, resumingSession);
 
         /*
          * THIRD, send a "change_cipher_spec" record followed by the
@@ -1208,6 +1217,7 @@ final class ClientHandshaker extends Handshaker {
                 m3.print(System.out);
             }
             m3.write(output);
+            handshakeState.update(m3, resumingSession);
             output.doHashes();
         }
 
@@ -1265,6 +1275,8 @@ final class ClientHandshaker extends Handshaker {
         if (resumingSession) {
             input.digestNow();
             sendChangeCipherAndFinish(true);
+        } else {
+            handshakeFinished = true;
         }
         session.setLastAccessedTime(System.currentTimeMillis());
 
@@ -1310,13 +1322,6 @@ final class ClientHandshaker extends Handshaker {
         if (secureRenegotiation) {
             clientVerifyData = mesg.getVerifyData();
         }
-
-        /*
-         * Update state machine so server MUST send 'finished' next.
-         * (In "long" handshake case; in short case, we're responding
-         * to its message.)
-         */
-        state = HandshakeMessage.ht_finished - 1;
     }
 
 
@@ -1421,6 +1426,24 @@ final class ClientHandshaker extends Handshaker {
                             session = null;
                         }
                     }
+                }
+            }
+
+            // ensure that the endpoint identification algorithm matches the
+            // one in the session
+            String identityAlg = getEndpointIdentificationAlgorithmSE();
+            if (session != null && identityAlg != null) {
+
+                String sessionIdentityAlg =
+                        session.getEndpointIdentificationAlgorithm();
+                if (!Objects.equals(identityAlg, sessionIdentityAlg)) {
+
+                    if (debug != null && Debug.isOn("session")) {
+                        System.out.println("%% can't resume, endpoint id" +
+                                " algorithm does not match, requested: " +
+                                identityAlg + ", cached: " + sessionIdentityAlg);
+                    }
+                    session = null;
                 }
             }
 

--- a/bootstrap/src/main/java/sun/security/ssl/HandshakeMessage.java
+++ b/bootstrap/src/main/java/sun/security/ssl/HandshakeMessage.java
@@ -83,6 +83,8 @@ public abstract class HandshakeMessage {
 
     static final byte   ht_finished = 20;
 
+    static final byte   ht_not_applicable         = -1;     // N/A
+
     // BEGIN GRIZZLY NPN
     // Defined by Draft03, section 3:
     //  A new handshake message type ("next_protocol(67)") is defined.

--- a/bootstrap/src/main/java/sun/security/ssl/Handshaker.java
+++ b/bootstrap/src/main/java/sun/security/ssl/Handshaker.java
@@ -169,7 +169,7 @@ abstract class Handshaker {
 
     // Could probably use a java.util.concurrent.atomic.AtomicReference
     // here instead of using this lock.  Consider changing.
-    private final Object thrownLock = new Object();
+    private Object thrownLock = new Object();
 
     // Class and subclass dynamic debugging support
     static final Debug debug = Debug.getInstance("ssl");
@@ -476,7 +476,7 @@ abstract class Handshaker {
     void setPeerSupportedSignAlgs(
             Collection<SignatureAndHashAlgorithm> algorithms) {
         peerSupportedSignAlgs =
-                new ArrayList<>(algorithms);
+                new ArrayList<SignatureAndHashAlgorithm>(algorithms);
     }
 
     Collection<SignatureAndHashAlgorithm> getPeerSupportedSignAlgs() {
@@ -1461,13 +1461,12 @@ abstract class Handshaker {
      */
     class DelegatedTask<E> implements Runnable {
 
-        private final PrivilegedExceptionAction<E> pea;
+        private PrivilegedExceptionAction<E> pea;
 
         DelegatedTask(PrivilegedExceptionAction<E> pea) {
             this.pea = pea;
         }
 
-        @Override
         public void run() {
             synchronized (engine) {
                 try {
@@ -1484,7 +1483,7 @@ abstract class Handshaker {
     }
 
     private <T> void delegateTask(PrivilegedExceptionAction<T> pea) {
-        delegatedTask = new DelegatedTask<>(pea);
+        delegatedTask = new DelegatedTask<T>(pea);
         taskDelegated = false;
         thrown = null;
     }

--- a/bootstrap/src/main/java/sun/security/ssl/Handshaker.java
+++ b/bootstrap/src/main/java/sun/security/ssl/Handshaker.java
@@ -169,7 +169,7 @@ abstract class Handshaker {
 
     // Could probably use a java.util.concurrent.atomic.AtomicReference
     // here instead of using this lock.  Consider changing.
-    private Object thrownLock = new Object();
+    private final Object thrownLock = new Object();
 
     // Class and subclass dynamic debugging support
     static final Debug debug = Debug.getInstance("ssl");
@@ -476,7 +476,7 @@ abstract class Handshaker {
     void setPeerSupportedSignAlgs(
             Collection<SignatureAndHashAlgorithm> algorithms) {
         peerSupportedSignAlgs =
-                new ArrayList<SignatureAndHashAlgorithm>(algorithms);
+                new ArrayList<>(algorithms);
     }
 
     Collection<SignatureAndHashAlgorithm> getPeerSupportedSignAlgs() {
@@ -1461,12 +1461,13 @@ abstract class Handshaker {
      */
     class DelegatedTask<E> implements Runnable {
 
-        private PrivilegedExceptionAction<E> pea;
+        private final PrivilegedExceptionAction<E> pea;
 
         DelegatedTask(PrivilegedExceptionAction<E> pea) {
             this.pea = pea;
         }
 
+        @Override
         public void run() {
             synchronized (engine) {
                 try {
@@ -1483,7 +1484,7 @@ abstract class Handshaker {
     }
 
     private <T> void delegateTask(PrivilegedExceptionAction<T> pea) {
-        delegatedTask = new DelegatedTask<T>(pea);
+        delegatedTask = new DelegatedTask<>(pea);
         taskDelegated = false;
         thrown = null;
     }

--- a/bootstrap/src/main/java/sun/security/ssl/Handshaker.java
+++ b/bootstrap/src/main/java/sun/security/ssl/Handshaker.java
@@ -168,7 +168,7 @@ abstract class Handshaker {
 
     // Could probably use a java.util.concurrent.atomic.AtomicReference
     // here instead of using this lock.  Consider changing.
-    private Object thrownLock = new Object();
+    private final Object thrownLock = new Object();
 
     // Class and subclass dynamic debugging support
     static final Debug debug = Debug.getInstance("ssl");
@@ -455,7 +455,7 @@ abstract class Handshaker {
     void setPeerSupportedSignAlgs(
             Collection<SignatureAndHashAlgorithm> algorithms) {
         peerSupportedSignAlgs =
-                new ArrayList<SignatureAndHashAlgorithm>(algorithms);
+                new ArrayList<>(algorithms);
     }
 
     Collection<SignatureAndHashAlgorithm> getPeerSupportedSignAlgs() {
@@ -1454,12 +1454,13 @@ abstract class Handshaker {
      */
     class DelegatedTask<E> implements Runnable {
 
-        private PrivilegedExceptionAction<E> pea;
+        private final PrivilegedExceptionAction<E> pea;
 
         DelegatedTask(PrivilegedExceptionAction<E> pea) {
             this.pea = pea;
         }
 
+        @Override
         public void run() {
             synchronized (engine) {
                 try {
@@ -1476,7 +1477,7 @@ abstract class Handshaker {
     }
 
     private <T> void delegateTask(PrivilegedExceptionAction<T> pea) {
-        delegatedTask = new DelegatedTask<T>(pea);
+        delegatedTask = new DelegatedTask<>(pea);
         taskDelegated = false;
         thrown = null;
     }

--- a/bootstrap/src/main/java/sun/security/ssl/Handshaker.java
+++ b/bootstrap/src/main/java/sun/security/ssl/Handshaker.java
@@ -33,7 +33,6 @@ import javax.net.ssl.*;
 import sun.misc.HexDumpEncoder;
 
 import sun.security.internal.spec.*;
-import sun.security.internal.interfaces.TlsMasterSecret;
 
 import sun.security.ssl.HandshakeMessage.*;
 import sun.security.ssl.CipherSuite.*;
@@ -114,10 +113,14 @@ abstract class Handshaker {
     HandshakeHash handshakeHash;
     HandshakeInStream input;
     HandshakeOutStream output;
-    int state;
     SSLContextImpl sslContext;
     RandomCookie clnt_random, svr_random;
     SSLSessionImpl session;
+    HandshakeStateManager handshakeState;
+    boolean clientHelloDelivered;
+    boolean serverHelloRequested;
+    boolean handshakeActivated;
+    boolean handshakeFinished;
 
     // current CipherSuite. Never null, initially SSL_NULL_WITH_NULL_NULL
     CipherSuite cipherSuite;
@@ -130,10 +133,6 @@ abstract class Handshaker {
 
     // True if it's OK to start a new SSL session
     boolean enableNewSession;
-
-    // True if session keys have been calculated and the caller may receive
-    // and process a ChangeCipherSpec message
-    private boolean sessKeysCalculated;
 
     // Whether local cipher suites preference should be honored during
     // handshaking?
@@ -278,9 +277,13 @@ abstract class Handshaker {
         this.secureRenegotiation = secureRenegotiation;
         this.clientVerifyData = clientVerifyData;
         this.serverVerifyData = serverVerifyData;
-        enableNewSession = true;
-        invalidated = false;
-        sessKeysCalculated = false;
+        this.enableNewSession = true;
+        this.invalidated = false;
+        this.handshakeState = new HandshakeStateManager();
+        this.clientHelloDelivered = false;
+        this.serverHelloRequested = false;
+        this.handshakeActivated = false;
+        this.handshakeFinished = false;
 
         setCipherSuite(CipherSuite.C_NULL);
         setEnabledProtocols(enabledProtocols);
@@ -290,22 +293,6 @@ abstract class Handshaker {
         } else {        // engine != null
             algorithmConstraints = new SSLAlgorithmConstraints(engine, true);
         }
-
-
-        //
-        // In addition to the connection state machine, controlling
-        // how the connection deals with the different sorts of records
-        // that get sent (notably handshake transitions!), there's
-        // also a handshaking state machine that controls message
-        // sequencing.
-        //
-        // It's a convenient artifact of the protocol that this can,
-        // with only a couple of minor exceptions, be driven by the
-        // type constant for the last message seen:  except for the
-        // client's cert verify, those constants are in a convenient
-        // order to drastically simplify state machine checking.
-        //
-        state = -2;  // initialized but not activated
     }
 
     /*
@@ -384,14 +371,6 @@ abstract class Handshaker {
             return conn.getAcc();
         } else {
             return engine.getAcc();
-        }
-    }
-
-    final boolean receivedChangeCipherSpec() {
-        if (conn != null) {
-            return conn.receivedChangeCipherSpec();
-        } else {
-            return engine.receivedChangeCipherSpec();
         }
     }
 
@@ -574,8 +553,7 @@ abstract class Handshaker {
             engine.outputRecord.setHelloVersion(helloVersion);
         }
 
-        // move state to activated
-        state = -1;
+        handshakeActivated = true;
     }
 
     /**
@@ -920,7 +898,7 @@ abstract class Handshaker {
      * this freshly created session can become the current one.
      */
     boolean isDone() {
-        return state == HandshakeMessage.ht_finished;
+        return started() && handshakeState.isEmpty() && handshakeFinished;
     }
 
 
@@ -1029,6 +1007,13 @@ abstract class Handshaker {
                 return;
             }
 
+            // Set the flags in the message receiving side.
+            if (messageType == HandshakeMessage.ht_client_hello) {
+                clientHelloDelivered = true;
+            } else if (messageType == HandshakeMessage.ht_hello_request) {
+                serverHelloRequested = true;
+            }
+
             /*
              * Process the message.  We require
              * that processMessage() consumes the entire message.  In
@@ -1063,15 +1048,14 @@ abstract class Handshaker {
      * In activated state, the handshaker may not send any messages out.
      */
     boolean activated() {
-        return state >= -1;
+        return handshakeActivated;
     }
 
     /**
      * Returns true iff the handshaker has sent any messages.
      */
     boolean started() {
-        return state >= 0;  // 0: HandshakeMessage.ht_hello_request
-        // 1: HandshakeMessage.ht_client_hello
+        return (serverHelloRequested || clientHelloDelivered);
     }
 
 
@@ -1081,11 +1065,13 @@ abstract class Handshaker {
      * the subclass returns.  NOP if handshaking's already started.
      */
     void kickstart() throws IOException {
-        if (state >= 0) {
+        if ((isClient && clientHelloDelivered) ||
+                (!isClient && serverHelloRequested)) {
             return;
         }
 
         HandshakeMessage m = getKickstartMessage();
+        handshakeState.update(m, resumingSession);
 
         if (debug != null && Debug.isOn("handshake")) {
             m.print(System.out);
@@ -1093,7 +1079,14 @@ abstract class Handshaker {
         m.write(output);
         output.flush();
 
-        state = m.messageType();
+        // Set the flags in the message delivering side.
+        int handshakeType = m.messageType();
+        if (handshakeType == HandshakeMessage.ht_hello_request) {
+            serverHelloRequested = true;
+        } else {        // HandshakeMessage.ht_client_hello
+            clientHelloDelivered = true;
+        }
+
     }
 
     /**
@@ -1125,16 +1118,6 @@ abstract class Handshaker {
 
         output.flush(); // i.e. handshake data
 
-        /*
-         * The write cipher state is protected by the connection write lock
-         * so we must grab it while making the change. We also
-         * make sure no writes occur between sending the ChangeCipherSpec
-         * message, installing the new cipher state, and sending the
-         * Finished message.
-         *
-         * We already hold SSLEngine/SSLSocket "this" by virtue
-         * of this being called from the readRecord code.
-         */
         OutputRecord r;
         if (conn != null) {
             r = new OutputRecord(Record.ct_change_cipher_spec);
@@ -1145,14 +1128,27 @@ abstract class Handshaker {
         r.setVersion(protocolVersion);
         r.write(1);     // single byte of data
 
+        /*
+         * The write cipher state is protected by the connection write lock
+         * so we must grab it while making the change. We also
+         * make sure no writes occur between sending the ChangeCipherSpec
+         * message, installing the new cipher state, and sending the
+         * Finished message.
+         *
+         * We already hold SSLEngine/SSLSocket "this" by virtue
+         * of this being called from the readRecord code.
+         */
         if (conn != null) {
             conn.writeLock.lock();
             try {
+                handshakeState.changeCipherSpec(false, isClient);
                 conn.writeRecord(r);
                 conn.changeWriteCiphers();
                 if (debug != null && Debug.isOn("handshake")) {
                     mesg.print(System.out);
                 }
+
+                handshakeState.update(mesg, resumingSession);
                 mesg.write(output);
                 output.flush();
             } finally {
@@ -1160,6 +1156,7 @@ abstract class Handshaker {
             }
         } else {
             synchronized (engine.writeLock) {
+                handshakeState.changeCipherSpec(false, isClient);
                 engine.writeRecord((EngineOutputRecord)r);
                 engine.changeWriteCiphers();
 
@@ -1170,6 +1167,8 @@ abstract class Handshaker {
                 if (debug != null && Debug.isOn("handshake")) {
                     mesg.print(System.out);
                 }
+
+                handshakeState.update(mesg, resumingSession);
                 mesg.write(output);
 
                 if (lastMessage) {
@@ -1178,6 +1177,13 @@ abstract class Handshaker {
                 output.flush();
             }
         }
+        if (lastMessage) {
+            handshakeFinished = true;
+        }
+    }
+
+    void receiveChangeCipherSpec() throws IOException {
+        handshakeState.changeCipherSpec(true, isClient);
     }
 
     /*
@@ -1359,10 +1365,6 @@ abstract class Handshaker {
             throw new ProviderException(e);
         }
 
-        // Mark a flag that allows outside entities (like SSLSocket/SSLEngine)
-        // determine if a ChangeCipherSpec message could be processed.
-        sessKeysCalculated = true;
-
         //
         // Dump the connection keys as they're generated.
         //
@@ -1415,15 +1417,6 @@ abstract class Handshaker {
                 System.out.flush();
             }
         }
-    }
-
-    /**
-     * Return whether or not the Handshaker has derived session keys for
-     * this handshake.  This is used for determining readiness to process
-     * an incoming ChangeCipherSpec message.
-     */
-    boolean sessionKeysCalculated() {
-        return sessKeysCalculated;
     }
 
     private static void printHex(HexDumpEncoder dump, byte[] bytes) {

--- a/bootstrap/src/main/java/sun/security/ssl/SSLEngineImpl.java
+++ b/bootstrap/src/main/java/sun/security/ssl/SSLEngineImpl.java
@@ -19,6 +19,7 @@ package sun.security.ssl;
 import java.io.*;
 import java.nio.*;
 import java.util.*;
+import java.util.function.BiFunction;
 import java.security.*;
 
 import javax.crypto.BadPaddingException;
@@ -321,6 +322,8 @@ final public class SSLEngineImpl extends SSLEngine {
      */
     private boolean preferLocalCipherSuites = false;
 
+    private BiFunction<SSLEngine, List<String>, String> applicationProtocolSelector;
+
     /*
      * Class and subclass dynamic debugging support
      */
@@ -357,7 +360,7 @@ final public class SSLEngineImpl extends SSLEngine {
         }
 
         sslContext = ctx;
-        sess = SSLSessionImpl.nullSession;
+        sess = new SSLSessionImpl();
         handshakeSession = null;
 
         /*
@@ -484,6 +487,22 @@ final public class SSLEngineImpl extends SSLEngine {
         handshaker.setEnabledCipherSuites(enabledCipherSuites);
         handshaker.setEnableSessionCreation(enableSessionCreation);
     }
+
+
+    // Dummy implementation to avoid exceptions on newer JDK8 versions.
+    @Override
+    public synchronized void setHandshakeApplicationProtocolSelector(
+        BiFunction<SSLEngine, List<String>, String> selector) {
+        applicationProtocolSelector = selector;
+    }
+
+
+    // Dummy implementation to avoid exceptions on newer JDK8 versions.
+    @Override
+    public BiFunction<SSLEngine, List<String>, String> getHandshakeApplicationProtocolSelector() {
+        return this.applicationProtocolSelector;
+    }
+
 
     /*
      * Report the current status of the Handshaker
@@ -1173,7 +1192,7 @@ final public class SSLEngineImpl extends SSLEngine {
          * For now, force it to be large enough to handle any
          * valid SSL/TLS record.
          */
-        if (netData.remaining() < EngineOutputRecord.maxRecordSize) {
+        if (netData.remaining() < Record.maxRecordSize) {
             return new SSLEngineResult(
                     Status.BUFFER_OVERFLOW, getHSStatus(null), 0, 0);
         }

--- a/bootstrap/src/main/java/sun/security/ssl/SSLEngineImpl.java
+++ b/bootstrap/src/main/java/sun/security/ssl/SSLEngineImpl.java
@@ -203,11 +203,6 @@ final public class SSLEngineImpl extends SSLEngine {
     static final byte           clauth_required = 2;
 
     /*
-     * Flag indicating that the engine has received a ChangeCipherSpec message.
-     */
-    private boolean             receivedCCS;
-
-    /*
      * Flag indicating if the next record we receive MUST be a Finished
      * message. Temporarily set during the handshake to ensure that
      * a change cipher spec message is followed by a finished message.
@@ -368,7 +363,6 @@ final public class SSLEngineImpl extends SSLEngine {
          */
         roleIsServer = true;
         connectionState = cs_START;
-        receivedCCS = false;
 
         // default server name indication
         serverNames =
@@ -578,14 +572,6 @@ final public class SSLEngineImpl extends SSLEngine {
      * Synchronized on "this" from readRecord.
      */
     private void changeReadCiphers() throws SSLException {
-        if (connectionState != cs_HANDSHAKE
-                && connectionState != cs_RENEGOTIATE) {
-            throw new SSLProtocolException(
-                    "State error, change cipher specs");
-        }
-
-        // ... create decompressor
-
         CipherBox oldCipher = readCipher;
 
         try {
@@ -771,6 +757,10 @@ final public class SSLEngineImpl extends SSLEngine {
             synchronized (unwrapLock) {
                 return readNetRecord(ea);
             }
+        } catch (SSLProtocolException spe) {
+            // may be an unexpected handshake message
+            fatal(Alerts.alert_unexpected_message, spe.getMessage(), spe);
+            return null;  // make compiler happy
         } catch (Exception e) {
             /*
              * Don't reset position so it looks like we didn't
@@ -1024,7 +1014,6 @@ final public class SSLEngineImpl extends SSLEngine {
 
                         if (handshaker.invalidated) {
                             handshaker = null;
-                            receivedCCS = false;
                             // if state is cs_RENEGOTIATE, revert it to cs_DATA
                             if (connectionState == cs_RENEGOTIATE) {
                                 connectionState = cs_DATA;
@@ -1043,8 +1032,6 @@ final public class SSLEngineImpl extends SSLEngine {
                             }
                             handshaker = null;
                             connectionState = cs_DATA;
-                            receivedCCS = false;
-
                             // No handshakeListeners here.  That's a
                             // SSLSocket thing.
                         } else if (handshaker.taskOutstanding()) {
@@ -1082,25 +1069,17 @@ final public class SSLEngineImpl extends SSLEngine {
 
                     case Record.ct_change_cipher_spec:
                         if ((connectionState != cs_HANDSHAKE
-                                && connectionState != cs_RENEGOTIATE)
-                                || !handshaker.sessionKeysCalculated()
-                                || receivedCCS) {
+                                && connectionState != cs_RENEGOTIATE)) {
                             // For the CCS message arriving in the wrong state
                             fatal(Alerts.alert_unexpected_message,
                                     "illegal change cipher spec msg, conn state = "
-                                            + connectionState + ", handshake state = "
-                                            + handshaker.state);
+                                            + connectionState);
                         } else if (inputRecord.available() != 1
                                 || inputRecord.read() != 1) {
                             // For structural/content issues with the CCS
                             fatal(Alerts.alert_unexpected_message,
                                     "Malformed change cipher spec msg");
                         }
-
-                        // Once we've received CCS, update the flag.
-                        // If the remote endpoint sends it again in this handshake
-                        // we won't process it.
-                        receivedCCS = true;
 
                         //
                         // The first message after a change_cipher_spec
@@ -1109,6 +1088,7 @@ final public class SSLEngineImpl extends SSLEngine {
                         // to be checked by a minor tweak to the state
                         // machine.
                         //
+                        handshaker.receiveChangeCipherSpec();
                         changeReadCiphers();
                         // next message MUST be a finished message
                         expectingFinished = true;
@@ -1182,6 +1162,10 @@ final public class SSLEngineImpl extends SSLEngine {
             synchronized (wrapLock) {
                 return writeAppRecord(ea);
             }
+        } catch (SSLProtocolException spe) {
+            // may be an unexpected handshake message
+            fatal(Alerts.alert_unexpected_message, spe.getMessage(), spe);
+            return null;  // make compiler happy
         } catch (Exception e) {
             ea.resetPos();
 
@@ -1943,13 +1927,21 @@ final public class SSLEngineImpl extends SSLEngine {
 
             case cs_START:
             /*
-             * If we need to change the engine mode and the enabled
-             * protocols haven't specifically been set by the user,
-             * change them to the corresponding default ones.
+             * If we need to change the socket mode and the enabled
+             * protocols and cipher suites haven't specifically been
+             * set by the user, change them to the corresponding
+             * default ones.
              */
-                if (roleIsServer != (!flag) &&
-                        sslContext.isDefaultProtocolList(enabledProtocols)) {
-                    enabledProtocols = sslContext.getDefaultProtocolList(!flag);
+                if (roleIsServer != (!flag)) {
+                    if (sslContext.isDefaultProtocolList(enabledProtocols)) {
+                        enabledProtocols =
+                                sslContext.getDefaultProtocolList(!flag);
+                    }
+
+                    if (sslContext.isDefaultCipherSuiteList(enabledCipherSuites)) {
+                        enabledCipherSuites =
+                                sslContext.getDefaultCipherSuiteList(!flag);
+                    }
                 }
 
                 roleIsServer = !flag;
@@ -2135,14 +2127,6 @@ final public class SSLEngineImpl extends SSLEngine {
                 handshaker.setSNIServerNames(serverNames);
             }
         }
-    }
-
-    /*
-     * Returns a boolean indicating whether the ChangeCipherSpec message
-     * has been received for this handshake.
-     */
-    boolean receivedChangeCipherSpec() {
-        return receivedCCS;
     }
 
     /**

--- a/bootstrap/src/main/java/sun/security/ssl/SSLEngineImpl.java
+++ b/bootstrap/src/main/java/sun/security/ssl/SSLEngineImpl.java
@@ -19,7 +19,6 @@ package sun.security.ssl;
 import java.io.*;
 import java.nio.*;
 import java.util.*;
-import java.util.function.BiFunction;
 import java.security.*;
 
 import javax.crypto.BadPaddingException;
@@ -322,8 +321,6 @@ final public class SSLEngineImpl extends SSLEngine {
      */
     private boolean preferLocalCipherSuites = false;
 
-    private BiFunction<SSLEngine, List<String>, String> applicationProtocolSelector;
-
     /*
      * Class and subclass dynamic debugging support
      */
@@ -360,7 +357,7 @@ final public class SSLEngineImpl extends SSLEngine {
         }
 
         sslContext = ctx;
-        sess = new SSLSessionImpl();
+        sess = SSLSessionImpl.nullSession;
         handshakeSession = null;
 
         /*
@@ -487,22 +484,6 @@ final public class SSLEngineImpl extends SSLEngine {
         handshaker.setEnabledCipherSuites(enabledCipherSuites);
         handshaker.setEnableSessionCreation(enableSessionCreation);
     }
-
-
-    // Dummy implementation to avoid exceptions on newer JDK8 versions.
-    @Override
-    public synchronized void setHandshakeApplicationProtocolSelector(
-        BiFunction<SSLEngine, List<String>, String> selector) {
-        applicationProtocolSelector = selector;
-    }
-
-
-    // Dummy implementation to avoid exceptions on newer JDK8 versions.
-    @Override
-    public BiFunction<SSLEngine, List<String>, String> getHandshakeApplicationProtocolSelector() {
-        return this.applicationProtocolSelector;
-    }
-
 
     /*
      * Report the current status of the Handshaker
@@ -1192,7 +1173,7 @@ final public class SSLEngineImpl extends SSLEngine {
          * For now, force it to be large enough to handle any
          * valid SSL/TLS record.
          */
-        if (netData.remaining() < Record.maxRecordSize) {
+        if (netData.remaining() < EngineOutputRecord.maxRecordSize) {
             return new SSLEngineResult(
                     Status.BUFFER_OVERFLOW, getHSStatus(null), 0, 0);
         }

--- a/bootstrap/src/main/java/sun/security/ssl/ServerHandshaker.java
+++ b/bootstrap/src/main/java/sun/security/ssl/ServerHandshaker.java
@@ -200,21 +200,14 @@ final class ServerHandshaker extends Handshaker {
     @Override
     void processMessage(byte type, int message_len)
             throws IOException {
-        //
-        // In SSLv3 and TLS, messages follow strictly increasing
-        // numerical order _except_ for one annoying special case.
-        //
-        if ((state >= type)
-                && (state != HandshakeMessage.ht_client_key_exchange
-                && type != HandshakeMessage.ht_certificate_verify)) {
-            throw new SSLProtocolException(
-                    "Handshake message sequence violation, state = " + state
-                            + ", type = " + type);
-        }
+
+        // check the handshake state
+        handshakeState.check(type);
 
         switch (type) {
             case HandshakeMessage.ht_client_hello:
                 ClientHello ch = new ClientHello(input, message_len);
+                handshakeState.update(ch, resumingSession);
                 /*
                  * send it off for processing.
                  */
@@ -227,7 +220,9 @@ final class ServerHandshaker extends Handshaker {
                             "client sent unsolicited cert chain");
                     // NOTREACHED
                 }
-                this.clientCertificate(new CertificateMsg(input));
+                CertificateMsg certificateMsg = new CertificateMsg(input);
+                handshakeState.update(certificateMsg, resumingSession);
+                this.clientCertificate(certificateMsg);
                 break;
 
             case HandshakeMessage.ht_client_key_exchange:
@@ -245,17 +240,20 @@ final class ServerHandshaker extends Handshaker {
                                 protocolVersion, clientRequestedVersion,
                                 sslContext.getSecureRandom(), input,
                                 message_len, privateKey);
+                        handshakeState.update(pms, resumingSession);
                         preMasterSecret = this.clientKeyExchange(pms);
                         break;
                     case K_KRB5:
                     case K_KRB5_EXPORT:
-                        preMasterSecret = this.clientKeyExchange(
+                        KerberosClientKeyExchange kke =
                                 new KerberosClientKeyExchange(protocolVersion,
                                         clientRequestedVersion,
                                         sslContext.getSecureRandom(),
                                         input,
                                         this.getAccSE(),
-                                        serviceCreds));
+                                        serviceCreds);
+                        handshakeState.update(kke, resumingSession);
+                        preMasterSecret = this.clientKeyExchange(kke);
                         break;
                     case K_DHE_RSA:
                     case K_DHE_DSS:
@@ -266,16 +264,19 @@ final class ServerHandshaker extends Handshaker {
                      * protocol difference in these five flavors is in how
                      * the ServerKeyExchange message was constructed!
                      */
-                        preMasterSecret = this.clientKeyExchange(
-                                new DHClientKeyExchange(input));
+                        DHClientKeyExchange dhcke = new DHClientKeyExchange(input);
+                        handshakeState.update(dhcke, resumingSession);
+                        preMasterSecret = this.clientKeyExchange(dhcke);
                         break;
                     case K_ECDH_RSA:
                     case K_ECDH_ECDSA:
                     case K_ECDHE_RSA:
                     case K_ECDHE_ECDSA:
                     case K_ECDH_ANON:
-                        preMasterSecret = this.clientKeyExchange
-                                (new ECDHClientKeyExchange(input));
+                        ECDHClientKeyExchange ecdhcke =
+                                new ECDHClientKeyExchange(input);
+                        handshakeState.update(ecdhcke, resumingSession);
+                        preMasterSecret = this.clientKeyExchange(ecdhcke);
                         break;
                     default:
                         throw new SSLProtocolException
@@ -295,8 +296,11 @@ final class ServerHandshaker extends Handshaker {
                 break;
 
             case HandshakeMessage.ht_certificate_verify:
-                this.clientCertificateVerify(new CertificateVerify(input,
-                        getLocalSupportedSignAlgs(), protocolVersion));
+                CertificateVerify cvm =
+                        new CertificateVerify(input,
+                                getLocalSupportedSignAlgs(), protocolVersion);
+                handshakeState.update(cvm, resumingSession);
+                this.clientCertificateVerify(cvm);
                 break;
             // BEGIN GRIZZLY NPN
             case HandshakeMessage.ht_next_protocol:
@@ -304,34 +308,15 @@ final class ServerHandshaker extends Handshaker {
                 break;
             // END GRIZZLY NPN
             case HandshakeMessage.ht_finished:
-                // A ChangeCipherSpec record must have been received prior to
-                // reception of the Finished message (RFC 5246, 7.4.9).
-                if (!receivedChangeCipherSpec()) {
-                    fatalSE(Alerts.alert_handshake_failure,
-                            "Received Finished message before ChangeCipherSpec");
-                }
-
-                this.clientFinished(
-                        new Finished(protocolVersion, input, cipherSuite));
+                Finished cfm =
+                        new Finished(protocolVersion, input, cipherSuite);
+                handshakeState.update(cfm, resumingSession);
+                this.clientFinished(cfm);
                 break;
 
             default:
                 throw new SSLProtocolException(
                         "Illegal server handshake msg, " + type);
-        }
-
-        //
-        // Move state machine forward if the message handling
-        // code didn't already do so
-        //
-        if (state < type// BEGIN GRIZZLY NPN
-                && type != HandshakeMessage.ht_next_protocol) {
-            // END GRIZZLY NPN
-            if(type == HandshakeMessage.ht_certificate_verify) {
-                state = type + 2;    // an annoying special case
-            } else {
-                state = type;
-            }
         }
     }
 
@@ -382,7 +367,7 @@ final class ServerHandshaker extends Handshaker {
         //
         // This will not have any impact on server initiated renegotiation.
         if (rejectClientInitiatedRenego && !isInitialHandshake &&
-                state != HandshakeMessage.ht_hello_request) {
+                !serverHelloRequested) {
             fatalSE(Alerts.alert_handshake_failure,
                     "Client initiated renegotiation is not allowed");
         }
@@ -766,6 +751,25 @@ final class ServerHandshaker extends Handshaker {
                     }
                 }
 
+                // ensure that the endpoint identification algorithm matches the
+                // one in the session
+                String identityAlg = getEndpointIdentificationAlgorithmSE();
+                if (resumingSession && identityAlg != null) {
+
+                    String sessionIdentityAlg =
+                            previous.getEndpointIdentificationAlgorithm();
+                    if (!Objects.equals(identityAlg, sessionIdentityAlg)) {
+
+                        if (debug != null && Debug.isOn("session")) {
+                            System.out.println("%% can't resume, endpoint id"
+                                    + " algorithm does not match, requested: " +
+                                    identityAlg + ", cached: " +
+                                    sessionIdentityAlg);
+                        }
+                        resumingSession = false;
+                    }
+                }
+
                 if (resumingSession) {
                     CipherSuite suite = previous.getSuite();
                     // verify that the ciphersuite from the cached session
@@ -837,7 +841,8 @@ final class ServerHandshaker extends Handshaker {
                     sslContext.getSecureRandom(),
                     getHostAddressSE(), getPortSE(),
                     (requestedToUseEMS &&
-                            (protocolVersion.v >= ProtocolVersion.TLS10.v)));
+                            (protocolVersion.v >= ProtocolVersion.TLS10.v)),
+                    getEndpointIdentificationAlgorithmSE());
 
             if (protocolVersion.v >= ProtocolVersion.TLS12.v) {
                 if (peerSupportedSignAlgs != null) {
@@ -923,6 +928,7 @@ final class ServerHandshaker extends Handshaker {
             System.out.println("Cipher suite:  " + session.getSuite());
         }
         m1.write(output);
+        handshakeState.update(m1, resumingSession);
 
         //
         // If we are resuming a session, we finish writing handshake
@@ -962,6 +968,7 @@ final class ServerHandshaker extends Handshaker {
                 m2.print(System.out);
             }
             m2.write(output);
+            handshakeState.update(m2, resumingSession);
 
             // XXX has some side effects with OS TCP buffering,
             // leave it out for now
@@ -1057,6 +1064,7 @@ final class ServerHandshaker extends Handshaker {
                 m3.print(System.out);
             }
             m3.write(output);
+            handshakeState.update(m3, resumingSession);
         }
 
         //
@@ -1106,6 +1114,7 @@ final class ServerHandshaker extends Handshaker {
                 m4.print(System.out);
             }
             m4.write(output);
+            handshakeState.update(m4, resumingSession);
         }
 
         /*
@@ -1117,6 +1126,7 @@ final class ServerHandshaker extends Handshaker {
             m5.print(System.out);
         }
         m5.write(output);
+        handshakeState.update(m5, resumingSession);
 
         /*
          * Flush any buffered messages so the client will see them.
@@ -1864,6 +1874,8 @@ final class ServerHandshaker extends Handshaker {
         if (!resumingSession) {
             input.digestNow();
             sendChangeCipherAndFinish(true);
+        } else {
+            handshakeFinished = true;
         }
 
         /*
@@ -1910,16 +1922,6 @@ final class ServerHandshaker extends Handshaker {
          */
         if (secureRenegotiation) {
             serverVerifyData = mesg.getVerifyData();
-        }
-
-        /*
-         * Update state machine so client MUST send 'finished' next
-         * The update should only take place if it is not in the fast
-         * handshake mode since the server has to wait for a finished
-         * message from the client.
-         */
-        if (finishedTag) {
-            state = HandshakeMessage.ht_finished;
         }
     }
 

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>grizzly-npn</artifactId>
         <groupId>org.glassfish.grizzly</groupId>
-        <version>2.0.1</version>
+        <version>2.0.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>grizzly-npn</artifactId>
         <groupId>org.glassfish.grizzly</groupId>
-        <version>2.0.2-SNAPSHOT</version>
+        <version>2.0.0.payara-p1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>grizzly-npn</artifactId>
         <groupId>org.glassfish.grizzly</groupId>
-        <version>2.0.0.payara-p1</version>
+        <version>2.0.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>grizzly-npn</artifactId>
         <groupId>org.glassfish.grizzly</groupId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <groupId>org.glassfish.grizzly</groupId>
     <artifactId>grizzly-npn</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.0.payara-p1</version>
+    <version>2.0.0.payara-p2-SNAPSHOT</version>
 
     <url>https://projects.eclipse.org/projects/ee4j.grizzly</url>
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <groupId>org.glassfish.grizzly</groupId>
     <artifactId>grizzly-npn</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.1</version>
+    <version>2.0.2-SNAPSHOT</version>
 
     <url>https://projects.eclipse.org/projects/ee4j.grizzly</url>
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -112,13 +112,27 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
+                <version>2.5.3</version>
                 <configuration>
                     <mavenExecutorId>forked-path</mavenExecutorId>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                     <preparationGoals>clean install</preparationGoals>
+                    <useReleaseProfile>false</useReleaseProfile>
                     <pushChanges>false</pushChanges>
-                    <goals>deploy -Dmaven.test.skip=true</goals>
+                    <arguments>${release.arguments}</arguments>
                 </configuration>
+             </plugin>
+             <plugin>
+                 <groupId>org.sonatype.plugins</groupId>
+                 <artifactId>nexus-staging-maven-plugin</artifactId>
+                     <version>1.6.8</version>
+                     <configuration>
+                         <serverId>ossrh</serverId>
+                         <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                         <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                         <!-- Skip based on the maven.deploy.skip property -->
+                         <skipNexusStagingDeployMojo>${maven.deploy.skip}</skipNexusStagingDeployMojo>
+                     </configuration>
             </plugin>
             <plugin>
                 <inherited>true</inherited>
@@ -131,16 +145,60 @@
         </plugins>
     </build>
     <profiles>
-        <profile>
-            <id>release-sign-artifacts</id>
-            <activation>
-                <property>
-                    <name>performRelease</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
+         <profile>
+            <id>release</id>
+	    <build>
                 <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>enforce-maven</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireMavenVersion>
+                                            <version>[3.0.4,)</version>
+                                            <message>Maven 3.0 through 3.0.3 inclusive does not pass
+                                                correct settings.xml to Maven Release Plugin.</message>
+                                        </requireMavenVersion>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <inherited>true</inherited>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <aggregate>true</aggregate>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
@@ -153,6 +211,11 @@
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <extensions>true</extensions>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <groupId>org.glassfish.grizzly</groupId>
     <artifactId>grizzly-npn</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.0.0.payara-p1</version>
 
     <url>https://projects.eclipse.org/projects/ee4j.grizzly</url>
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <groupId>org.glassfish.grizzly</groupId>
     <artifactId>grizzly-npn</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
 
     <url>https://projects.eclipse.org/projects/ee4j.grizzly</url>
     <issueManagement>


### PR DESCRIPTION
Improving ConcurrentHashMaps using String key instead of SSLEngine instance

Tests
Tested on local environment by calling a rest service using https on Payara 6 Server
Build Environment:
Windows 11, Oracle JDK 8 u 251, Maven 3.8.3